### PR TITLE
Baidan/add null key update rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .rvmrc
 .rbenv*
 Gemfile.lock
+.idea

--- a/dynamodb.gemspec
+++ b/dynamodb.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'multi_json', '>= 1.3.7'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '2.8.0'
-  s.add_development_dependency 'webmock', '1.8.11'
+  s.add_development_dependency 'rspec', '3.11.0'
+  s.add_development_dependency 'webmock', '3.11.2'
 end
 

--- a/lib/dynamodb.rb
+++ b/lib/dynamodb.rb
@@ -80,6 +80,7 @@ module DynamoDB
       when "N" then v.include?('.') ? v.to_f : v.to_i
       when "S" then v.to_s
       when "SS","NS" then v
+      when "NULL" then nil
       else
         raise "Type not recoginized: #{k}"
       end

--- a/lib/dynamodb/version.rb
+++ b/lib/dynamodb/version.rb
@@ -1,3 +1,3 @@
 module DynamoDB
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end

--- a/spec/dynamodb/connection_spec.rb
+++ b/spec/dynamodb/connection_spec.rb
@@ -8,21 +8,21 @@ describe DynamoDB::Connection do
       stub_request(:post, "https://dynamodb.us-east-1.amazonaws.com/").
         to_return(status: 200, body: MultiJson.encode({"TableNames" => ["example"]}))
       result = connection.post :ListTables
-      result.data.should == {"TableNames" => ["example"]}
+      expect(result.data).to eq({"TableNames" => ["example"]})
     end
 
     it "creates a SuccessResponse when 200" do
       stub_request(:post, "https://dynamodb.us-east-1.amazonaws.com/").
         to_return(status: 200, body: "")
       result = connection.post :ListTables
-      result.should be_a_kind_of(DynamoDB::SuccessResponse)
+      expect(result).to be_a_kind_of(DynamoDB::SuccessResponse)
     end
 
     it "creates a FailureResponse when 400" do
       stub_request(:post, "https://dynamodb.us-east-1.amazonaws.com/").
         to_return(status: 400, body: "")
       result = connection.post :ListTables
-      result.should be_a_kind_of(DynamoDB::FailureResponse)
+      expect(result).to be_a_kind_of(DynamoDB::FailureResponse)
     end
   end
 end

--- a/spec/dynamodb/failure_response_spec.rb
+++ b/spec/dynamodb/failure_response_spec.rb
@@ -3,25 +3,25 @@ require "spec_helper"
 describe DynamoDB::FailureResponse do
   describe "#error" do
     it "returns a ClientError if the HTTP response code is between 400 and 499" do
-      http_response = stub("Response", code: "401", message: "Not authorized", body: "Error details")
+      http_response = double("Response", code: "401", message: "Not authorized", body: "Error details")
       response = DynamoDB::FailureResponse.new(http_response)
-      response.error.should be_an_instance_of(DynamoDB::ClientError)
-      response.error.message.should == "401: Not authorized"
-      response.body.should == "Error details"
+      expect(response.error).to be_an_instance_of(DynamoDB::ClientError)
+      expect(response.error.message).to eq("401: Not authorized")
+      expect(response.body).to eq("Error details")
     end
 
     it "returns a ServerError if the HTTP response code is between 500 and 599" do
-      http_response = stub("Response", code: "500", message: "Internal server error", body: "")
+      http_response = double("Response", code: "500", message: "Internal server error", body: "")
       response = DynamoDB::FailureResponse.new(http_response)
-      response.error.should be_an_instance_of(DynamoDB::ServerError)
-      response.error.message.should == "500: Internal server error"
+      expect(response.error).to be_an_instance_of(DynamoDB::ServerError)
+      expect(response.error.message).to eq("500: Internal server error")
     end
 
     it "returns a ServerError otherwise" do
-      http_response = stub("Response", code: "0", message: "")
+      http_response = double("Response", code: "0", message: "")
       response = DynamoDB::FailureResponse.new(http_response)
-      response.error.should be_an_instance_of(DynamoDB::ServerError)
-      response.error.message.should == "0: "
+      expect(response.error).to be_an_instance_of(DynamoDB::ServerError)
+      expect(response.error.message).to eq("0: ")
     end
   end
 end

--- a/spec/dynamodb/http_handler_spec.rb
+++ b/spec/dynamodb/http_handler_spec.rb
@@ -4,7 +4,7 @@ describe DynamoDB::HttpHandler do
   describe "#handle" do
     let(:http_handler) { DynamoDB::HttpHandler.new }
     let(:request) {
-      stub(DynamoDB::Request,
+      double(DynamoDB::Request,
         uri:     URI("https://dynamo.local/"),
         headers: {},
         body:    "{}"
@@ -14,23 +14,23 @@ describe DynamoDB::HttpHandler do
     it "performs an HTTP request given a DynamoDB::Request" do
       http_request = stub_request(:post, "https://dynamo.local/").to_return(status: 200)
       http_handler.handle(request)
-      http_request.should have_been_requested
+      expect(http_request).to have_been_requested
     end
 
     it "returns a DynamoDB::SuccessResponse for successes" do
       stub_request(:post, "https://dynamo.local/").to_return(status: 200)
 
       response = http_handler.handle(request)
-      response.should be_an_instance_of(DynamoDB::SuccessResponse)
-      response.should be_success
+      expect(response).to be_an_instance_of(DynamoDB::SuccessResponse)
+      expect(response).to be_success
     end
 
     it "returns a DynamoDB::Response for failures" do
       stub_request(:post, "https://dynamo.local/").to_return(status: 500, body: "Server errors")
 
       response = http_handler.handle(request)
-      response.should be_an_instance_of(DynamoDB::FailureResponse)
-      response.should_not be_success
+      expect(response).to be_an_instance_of(DynamoDB::FailureResponse)
+      expect(response).not_to be_success
     end
 
     it "returns a DynamoDB::Response for network errors" do
@@ -38,23 +38,22 @@ describe DynamoDB::HttpHandler do
       stub_request(:post, "https://dynamo.local/").to_raise(error)
 
       response = http_handler.handle(request)
-      response.should be_an_instance_of(DynamoDB::FailureResponse)
-      response.should_not be_success
-      response.error.should == error
-      response.body.should be_nil
+      expect(response).to be_an_instance_of(DynamoDB::FailureResponse)
+      expect(response).not_to be_success
+      expect(response.error).to eq(error)
+      expect(response.body).to be_nil
     end
 
     it "respects a custom timeout option (set on initialize)" do
       stub_request(:post, "https://dynamo.local/").to_return(status: 200)
-      connection = Net::HTTP::ConnectionPool::Connection.any_instance
-      connection.should_receive(:read_timeout=).with(5)
+      expect_any_instance_of(Net::HTTP::ConnectionPool::Connection).to receive(:read_timeout=).with(5)
       http_handler.handle(request)
     end
   end
 
   describe "#build_http_request" do
     it "converts a DynamoDB::Request into a Net::HTTP::Post" do
-      request = stub(DynamoDB::Request,
+      request = double(DynamoDB::Request,
         uri:      URI("https://dynamo.local/"),
         headers:  {"content-type" => "application/json"},
         body:     "POST body"
@@ -62,10 +61,10 @@ describe DynamoDB::HttpHandler do
 
       http_handler = DynamoDB::HttpHandler.new
       http_request = http_handler.build_http_request(request)
-      http_request.should be_an_instance_of(Net::HTTP::Post)
-      http_request.path.should == "https://dynamo.local/"
-      http_request["content-type"].should == "application/json"
-      http_request.body.should == "POST body"
+      expect(http_request).to be_an_instance_of(Net::HTTP::Post)
+      expect(http_request.path).to eq("https://dynamo.local/")
+      expect(http_request["content-type"]).to eq("application/json")
+      expect(http_request.body).to eq("POST body")
     end
   end
 end

--- a/spec/dynamodb/request_spec.rb
+++ b/spec/dynamodb/request_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe DynamoDB::Request do
   it "signs the request" do
-    Time.stub(now: Time.parse("20130508T201304Z"))
+    allow(Time).to receive_messages(now: Time.parse("20130508T201304Z"))
 
     uri = URI("https://dynamodb.us-east-1.amazonaws.com/")
     signer = AWS4::Signer.new(
@@ -17,7 +17,7 @@ describe DynamoDB::Request do
       operation: "DynamoDB_20111205.ListTables",
     )
 
-    request.headers.should == {
+    expect(request.headers).to eq({
       "Content-Type"=>"application/x-amz-json-1.0",
       "Content-Length"=>"2",
       "Date"=>"Wed, 08 May 2013 20:13:04 GMT",
@@ -27,6 +27,6 @@ describe DynamoDB::Request do
       "X-AMZ-Date"=>"20130508T201304Z",
       "X-AMZ-Content-SHA256"=>"44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
       "Authorization"=>"AWS4-HMAC-SHA256 Credential=access_key_id/20130508/us-east-1/dynamodb/aws4_request, SignedHeaders=content-length;content-type;date;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-target, Signature=9e551627237673b4deaa2c22fd3b3777d6d0705facd35b56b289e357c4995c46"
-    }
+    })
   end
 end

--- a/spec/dynamodb/success_response_spec.rb
+++ b/spec/dynamodb/success_response_spec.rb
@@ -45,7 +45,8 @@ describe DynamoDB::SuccessResponse do
             "created_at" => {"N" => "1321564309.99428"},
             "disabled"   => {"N" => "1"},
             "group_id"   => {"N" => "1"},
-            "person_id"  => {"N" => "1501"}
+            "person_id"  => {"N" => "1501"},
+            "pinned_at"  => {"NULL" => true}
           }
         ],
         "Count" => 1,

--- a/spec/dynamodb/success_response_spec.rb
+++ b/spec/dynamodb/success_response_spec.rb
@@ -9,9 +9,10 @@ describe DynamoDB::SuccessResponse do
           "RangeKeyElement" => {"N" => "1501"}
         }
       }
-      http_response = stub(Net::HTTPResponse, body: MultiJson.dump(body))
-      response = DynamoDB::SuccessResponse.new(http_response)
-      response.hash_key_element.should == 1
+      stub = stub_request(:post, "https://dynamodb.local").
+        to_return(status: 201, body: MultiJson.dump(body))
+      response = DynamoDB::SuccessResponse.new(stub.response)
+      expect(response.hash_key_element).to eq(1)
     end
   end
 
@@ -23,9 +24,10 @@ describe DynamoDB::SuccessResponse do
           "RangeKeyElement" => {"N" => "1501"}
         }
       }
-      http_response = stub(Net::HTTPResponse, body: MultiJson.dump(body))
-      response = DynamoDB::SuccessResponse.new(http_response)
-      response.range_key_element.should == 1501
+      stub = stub_request(:post, "https://dynamodb.local").
+        to_return(status: 201, body: MultiJson.dump(body))
+      response = DynamoDB::SuccessResponse.new(stub.response)
+      expect(response.range_key_element).to eq(1501)
     end
   end
 
@@ -52,20 +54,21 @@ describe DynamoDB::SuccessResponse do
         "Count" => 1,
         "ConsumedCapacityUnits" => 0.5
       }
-      http_response = stub(Net::HTTPResponse, body: MultiJson.dump(body))
+      stub = stub_request(:post, "https://dynamodb.local").
+        to_return(status: 201, body: MultiJson.dump(body))
 
-      response = DynamoDB::SuccessResponse.new(http_response)
-      response.items[0]["name"].should == "John Smith"
-      response.items[0]["created_at"].should == 1321564309.99428
-      response.items[0]["disabled"].should == 0
-      response.items[0]["group_id"].should == 1
-      response.items[0]["person_id"].should == 1500
+      response = DynamoDB::SuccessResponse.new(stub.response)
+      expect(response.items[0]["name"]).to eq("John Smith")
+      expect(response.items[0]["created_at"]).to eq(1321564309.99428)
+      expect(response.items[0]["disabled"]).to eq(0)
+      expect(response.items[0]["group_id"]).to eq(1)
+      expect(response.items[0]["person_id"]).to eq(1500)
 
-      response.items[1]["name"].should == "Jane Smith"
-      response.items[1]["created_at"].should == 1321564309.99428
-      response.items[1]["disabled"].should == 1
-      response.items[1]["group_id"].should == 1
-      response.items[1]["person_id"].should == 1501
+      expect(response.items[1]["name"]).to eq("Jane Smith")
+      expect(response.items[1]["created_at"]).to eq(1321564309.99428)
+      expect(response.items[1]["disabled"]).to eq(1)
+      expect(response.items[1]["group_id"]).to eq(1)
+      expect(response.items[1]["person_id"]).to eq(1501)
     end
   end
 
@@ -92,19 +95,20 @@ describe DynamoDB::SuccessResponse do
       }
     }
 
-    http_response = stub(Net::HTTPResponse, body: MultiJson.dump(body))
+    stub = stub_request(:post, "https://dynamodb.local").
+      to_return(status: 201, body: MultiJson.dump(body))
 
-    response = DynamoDB::SuccessResponse.new(http_response)
+    response = DynamoDB::SuccessResponse.new(stub.response)
 
-    response.responses["table_name"][0]["text"].should == "hi"
-    response.responses["table_name"][0]["message_id"].should == 1000
-    response.responses["table_name"][0]["like_user_ids"].should == ["1", "2"]
+    expect(response.responses["table_name"][0]["text"]).to eq("hi")
+    expect(response.responses["table_name"][0]["message_id"]).to eq(1000)
+    expect(response.responses["table_name"][0]["like_user_ids"]).to eq(["1", "2"])
 
-    response.responses["table_name"][1]["text"].should == "hello"
-    response.responses["table_name"][1]["message_id"].should == 2000
-    response.responses["table_name"][1]["like_user_ids"].should == ["3", "4"]
+    expect(response.responses["table_name"][1]["text"]).to eq("hello")
+    expect(response.responses["table_name"][1]["message_id"]).to eq(2000)
+    expect(response.responses["table_name"][1]["like_user_ids"]).to eq(["3", "4"])
 
-    response.responses["other_table_name"][0]["text"].should == "goodbye"
+    expect(response.responses["other_table_name"][0]["text"]).to eq("goodbye")
   end
 
   describe "#item" do
@@ -115,18 +119,22 @@ describe DynamoDB::SuccessResponse do
           "created_at" => {"N" => "1321564309.99428"},
           "disabled"   => {"N" => "0"},
           "group_id"   => {"N" => "1"},
-          "person_id"  => {"N" => "1500"}
+          "person_id"  => {"N" => "1500"},
+          "pinned_at"  => {"NULL" => true}
         },
         "ConsumedCapacityUnits" => 0.5
       }
-      http_response = stub(Net::HTTPResponse, body: MultiJson.dump(body))
+      stub = stub_request(:post, "https://dynamodb.local").
+        to_return(status: 201, body: MultiJson.dump(body))
 
-      response = DynamoDB::SuccessResponse.new(http_response)
-      response.item["name"].should == "John Smith"
-      response.item["created_at"].should == 1321564309.99428
-      response.item["disabled"].should == 0
-      response.item["group_id"].should == 1
-      response.item["person_id"].should == 1500
+
+      response = DynamoDB::SuccessResponse.new(stub.response)
+      expect(response.item["name"]).to eq("John Smith")
+      expect(response.item["created_at"]).to eq(1321564309.99428)
+      expect(response.item["disabled"]).to eq(0)
+      expect(response.item["group_id"]).to eq(1)
+      expect(response.item["person_id"]).to eq(1500)
+      expect(response.item["pinned_at"]).to be_nil
     end
   end
 end

--- a/spec/dynamodb_spec.rb
+++ b/spec/dynamodb_spec.rb
@@ -12,45 +12,45 @@ describe DynamoDB do
         :active => true
       }
 
-      DynamoDB.serialize(hash).should == {
+      expect(DynamoDB.serialize(hash)).to eq({
         "id" => {"N" => "1"},
         "name" => {"S" => "Gone with the Wind"},
         "published_at" => {"N" => published_at.to_f.to_s},
         "price" => {"N" => "11.99"},
         "active" => {"N" => "1"}
-      }
+      })
     end
 
     it "serializes a single value" do
-      DynamoDB.serialize(1).should == {"N" => "1"}
-      DynamoDB.serialize(1.5).should == {"N" => "1.5"}
-      DynamoDB.serialize("Hello World").should == {"S" => "Hello World"}
+      expect(DynamoDB.serialize(1)).to eq({"N" => "1"})
+      expect(DynamoDB.serialize(1.5)).to eq({"N" => "1.5"})
+      expect(DynamoDB.serialize("Hello World")).to eq({"S" => "Hello World"})
     end
 
     it "omits nil/blank values" do
-      DynamoDB.serialize("foo" => nil).should == {}
-      DynamoDB.serialize("foo" => "").should == {}
+      expect(DynamoDB.serialize("foo" => nil)).to eq({})
+      expect(DynamoDB.serialize("foo" => "")).to eq({})
     end
 
     it "serializes StringSet" do
-      DynamoDB.serialize(["foo", "bar", "foo"]).should == {"SS" => ["foo", "bar"]}
+      expect(DynamoDB.serialize(["foo", "bar", "foo"])).to eq({"SS" => ["foo", "bar"]})
     end
 
     it "serializes NumberSet" do
-      DynamoDB.serialize([1, 2, 1]).should == {"NS" => [1,2]}
+      expect(DynamoDB.serialize([1, 2, 1])).to eq({"NS" => [1,2]})
     end
 
     it "raises an error on mixed types" do
-      lambda {
+      expect {
         DynamoDB.serialize([1, "2", 1])
-      }.should raise_error
+      }.to raise_error
     end
   end
 
   describe "#deserialize" do
     it "deserializes single values" do
-      DynamoDB.deserialize({"N" => "123"}).should == 123
-      DynamoDB.deserialize({"S" => "Hello World"}).should == "Hello World"
+      expect(DynamoDB.deserialize({"N" => "123"})).to eq(123)
+      expect(DynamoDB.deserialize({"S" => "Hello World"})).to eq("Hello World")
     end
 
     it "deserializes from dynamo type format" do
@@ -63,11 +63,11 @@ describe DynamoDB do
         "active" => {"N" => "1"}
       }
       deserialized = DynamoDB.deserialize(item)
-      deserialized["id"].should == 1
-      deserialized["name"].should == "Gone with the Wind"
-      deserialized["published_at"].to_s.should == published_at.to_f.to_s
-      deserialized["price"].should == 11.99
-      deserialized["active"].should == 1
+      expect(deserialized["id"]).to eq(1)
+      expect(deserialized["name"]).to eq("Gone with the Wind")
+      expect(deserialized["published_at"].to_s).to eq(published_at.to_f.to_s)
+      expect(deserialized["price"]).to eq(11.99)
+      expect(deserialized["active"]).to eq(1)
     end
 
     it "deserializes StringSet and NumberSet" do
@@ -76,8 +76,16 @@ describe DynamoDB do
         "powerball" => {"NS" => [1,2]}
       }
       deserialized = DynamoDB.deserialize(item)
-      deserialized["turtles"].should == ["Leonardo", "Michelangelo"]
-      deserialized["powerball"].should == [1,2]
+      expect(deserialized["turtles"]).to eq(["Leonardo", "Michelangelo"])
+      expect(deserialized["powerball"]).to eq([1,2])
+    end
+
+    it "deserializes NULL" do
+      item = {
+        "turtles" => {"NULL" => true}
+      }
+      deserialized = DynamoDB.deserialize(item)
+      expect(deserialized["turtles"]).to be_nil
     end
   end
 end


### PR DESCRIPTION
Update to our custom ruby dyanmoBD lib. Allow parsing of NULL key, and update rspec. This lib should be removed from all our services in a favor of official aws-sdk, but for now this PR will provide quick fix for message service 